### PR TITLE
Add publish job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Integration Test
         run: ./ci/run_integration_tests.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,26 @@ jobs:
         if: env.RESULTS != 'success,success,success,success'
         run: false
         shell: bash
+
+  publish:
+    name: Publish release
+    #if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
+    needs:
+      - all-jobs-succeeded
+    runs-on: ubuntu-latest
+    #environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate version
+        run: |
+          TAG_VERSION=${{ github.ref_name }}
+          CARGO_VERSION="v$(grep '^version = ' Cargo.toml | cut -d '"' -f 2)"
+          if [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
+            echo "Tag version (${TAG_VERSION}) does not match version from Cargo (${CARGO_VERSION})"
+            exit 1
+          fi
+      - name: Cargo publish
+        run: cargo publish --verbose --dry-run
+        working-directory: ./parquet-key-management
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate version
         run: |
-          TAG_VERSION=${{ github.ref_name }}
+          #TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="v0.1.0"
           CARGO_VERSION="v$(grep '^version = ' Cargo.toml | cut -d '"' -f 2)"
           if [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
             echo "Tag version (${TAG_VERSION}) does not match version from Cargo (${CARGO_VERSION})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,24 +122,23 @@ jobs:
 
   publish:
     name: Publish release
-    #if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs:
       - all-jobs-succeeded
     runs-on: ubuntu-latest
-    #environment: release
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - name: Validate version
         run: |
-          #TAG_VERSION="${{ github.ref_name }}"
-          TAG_VERSION="v0.1.0"
+          TAG_VERSION="${{ github.ref_name }}"
           CARGO_VERSION="v$(grep '^version = ' Cargo.toml | cut -d '"' -f 2)"
           if [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
             echo "Tag version (${TAG_VERSION}) does not match version from Cargo (${CARGO_VERSION})"
             exit 1
           fi
       - name: Cargo publish
-        run: cargo publish --verbose --dry-run
+        run: cargo publish --verbose
         working-directory: ./parquet-key-management
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/generate-test-files/Cargo.toml
+++ b/generate-test-files/Cargo.toml
@@ -6,6 +6,7 @@ repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+publish = false
 
 [dependencies]
 parquet-key-management = { version = "0.1.0", path = "../parquet-key-management", features = ["_test_utils"] }


### PR DESCRIPTION
This adds a new CI job that will publish the `parquet-key-management` crate to crates.io when a new tag is pushed.