### PR TITLE
Run cippy with warnings treated as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Format check
         run: cargo fmt --verbose --check
       - name: Clippy
-        run: cargo clippy --verbose
+        run: cargo clippy --verbose -- --deny warnings
 
   docs:
     name: Build docs


### PR DESCRIPTION
I noticed that clippy was showing warnings that hadn't caused CI to fail. This PR runs clippy with `--deny warnings` to fix that, and also fixes the warning.