### PR TITLE
Cache key encryption keys when writing multiple files

### DIFF
--- a/parquet-key-management/src/key_unwrapper.rs
+++ b/parquet-key-management/src/key_unwrapper.rs
@@ -2,7 +2,7 @@ use crate::crypto_factory::DecryptionConfiguration;
 use crate::key_encryption;
 use crate::key_material::KeyMaterial;
 use crate::kms::KmsConnectionConfig;
-use crate::kms_manager::{KekCache, KmsManager};
+use crate::kms_manager::{KekReadCache, KmsManager};
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use parquet::encryption::decrypt::KeyRetriever;
@@ -15,7 +15,7 @@ pub(crate) struct KeyUnwrapper {
     kms_manager: Arc<KmsManager>,
     kms_connection_config: RwLock<Arc<KmsConnectionConfig>>,
     decryption_configuration: DecryptionConfiguration,
-    kek_cache: KekCache,
+    kek_cache: KekReadCache,
 }
 
 impl KeyUnwrapper {
@@ -24,7 +24,7 @@ impl KeyUnwrapper {
         kms_connection_config: Arc<KmsConnectionConfig>,
         decryption_configuration: DecryptionConfiguration,
     ) -> Self {
-        let kek_cache = kms_manager.get_kek_cache(
+        let kek_cache = kms_manager.get_kek_read_cache(
             &kms_connection_config,
             decryption_configuration.cache_lifetime(),
         );

--- a/parquet-key-management/src/kms_manager.rs
+++ b/parquet-key-management/src/kms_manager.rs
@@ -97,6 +97,15 @@ impl KmsManager {
             self.kek_write_caches.clear_expired(cleanup_interval);
         }
     }
+
+    #[cfg(test)]
+    pub fn cache_stats(&self) -> CacheStats {
+        CacheStats {
+            num_kms_clients: self.kms_client_cache.cache.lock().unwrap().len(),
+            num_kek_read_caches: self.kek_read_caches.cache.lock().unwrap().len(),
+            num_kek_write_caches: self.kek_write_caches.cache.lock().unwrap().len(),
+        }
+    }
 }
 
 struct ExpiringCache<TKey, TValue> {
@@ -210,6 +219,14 @@ impl KekCacheKey {
     pub fn new(key_access_token: String) -> Self {
         Self { key_access_token }
     }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct CacheStats {
+    pub num_kms_clients: usize,
+    pub num_kek_read_caches: usize,
+    pub num_kek_write_caches: usize,
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
Fixes #5 

This caches maps from master key identifiers to key encryption keys so they can be reused when encrypting multiple files. This reduces interactions required with the KMS both when writing and when reading, as the KEK ids are globally unique so a reader can also take advantage of cached keys across different files.