### PR TITLE
Bump required version of parquet crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 homepage = "https://github.com/G-Research/parquet-key-management-rs"
 repository = "https://github.com/G-Research/parquet-key-management-rs"
 readme = "README.md"
@@ -17,6 +17,6 @@ edition = "2021"
 rust-version = "1.81"
 
 [workspace.dependencies]
-arrow = { version = "=55.0", default-features = false }
-arrow-array = { version = "=55.0", default-features = false }
-parquet = { version = "=55.0", default-features = false, features = ["encryption"] }
+arrow = { version = ">=55.2", default-features = false }
+arrow-array = { version = ">=55.2", default-features = false }
+parquet = { version = ">=55.2", default-features = false, features = ["encryption"] }


### PR DESCRIPTION
The fix for handling key material and plaintext footers was included in the 55.2.0 parquet crate release (https://github.com/apache/arrow-rs/pull/7600), so we no longer need to fix the required version (see #15).

Fixes #14