### PR TITLE
Fix hidden lifetime warning

### DIFF
--- a/parquet-key-management/src/kms.rs
+++ b/parquet-key-management/src/kms.rs
@@ -50,7 +50,7 @@ impl KmsConnectionConfig {
     }
 
     /// Return the key access token inside a read lock.
-    pub(crate) fn read_key_access_token(&self) -> RwLockReadGuard<String> {
+    pub(crate) fn read_key_access_token(&self) -> RwLockReadGuard<'_, String> {
         self.key_access_token.read().unwrap()
     }
 


### PR DESCRIPTION
Rust 1.89.0 has added a new warning for hidden lifetime parameters: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Adding this lifetime parameter makes it clear that the `RwLockReadGuard` returned has a lifetime tied to the `KmsConnectionConfig`.