### PR TITLE
Use trusted publishing to publish crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
       - all-jobs-succeeded
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Validate version
@@ -152,8 +154,11 @@ jobs:
             echo "Tag version (${TAG_VERSION}) does not match version from Cargo (${CARGO_VERSION})"
             exit 1
           fi
+      - name: Setup trusted publishing credentials
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Cargo publish
         run: cargo publish --verbose
         working-directory: ./parquet-key-management
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
See https://crates.io/docs/trusted-publishing for more info.
The crate has been configured accordingly.
