### PR TITLE
Loosen dependencies to allow newer versions of arrow and parquet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Format check
         run: taplo format --check
       - name: Lint
-        run: taplo lint --default-schema-catalogs
+        run: taplo lint
 
   docs:
     name: Build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["parquet-key-management", "generate-test-files"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 homepage = "https://github.com/G-Research/parquet-key-management-rs"
 repository = "https://github.com/G-Research/parquet-key-management-rs"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-arrow = { version = "57.2", default-features = false }
-arrow-array = { version = "57.2", default-features = false }
-arrow-schema = { version = "57.2", default-features = false }
+arrow = { version = ">=57.2", default-features = false }
+arrow-array = { version = ">=57.2", default-features = false }
+arrow-schema = { version = ">=57.2", default-features = false }
 futures = { version = "0.3", default-features = false }
-parquet = { version = "57.2", default-features = false, features = ["encryption"] }
+parquet = { version = ">=57.2", default-features = false, features = ["encryption"] }
 tempfile = { version = "3.24", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-arrow = { version = ">=57.2", default-features = false }
-arrow-array = { version = ">=57.2", default-features = false }
-arrow-schema = { version = ">=57.2", default-features = false }
+arrow = { version = ">=57.2, <59", default-features = false }
+arrow-array = { version = ">=57.2, <59", default-features = false }
+arrow-schema = { version = ">=57.2, <59", default-features = false }
 futures = { version = "0.3", default-features = false }
-parquet = { version = ">=57.2", default-features = false, features = ["encryption"] }
+parquet = { version = ">=57.2, <59", default-features = false, features = ["encryption"] }
 tempfile = { version = "3.24", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }

--- a/parquet-key-management/Cargo.toml
+++ b/parquet-key-management/Cargo.toml
@@ -23,15 +23,15 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 
 # optional
 async-std = { version = "1", optional = true }
-datafusion-execution = { version = ">=52.1.0", default-features = false, features = [
+datafusion-execution = { version = ">=52.1.0, <54", default-features = false, features = [
   "parquet_encryption",
 ], optional = true }
-datafusion-common = { version = ">=52.1.0", default-features = false, features = [
+datafusion-common = { version = ">=52.1.0, <54", default-features = false, features = [
   "parquet",
   "parquet_encryption",
 ], optional = true }
 futures = { workspace = true, optional = true }
-object_store = { version = ">=0.12.5", default-features = false, optional = true }
+object_store = { version = ">=0.12.5, <0.14", default-features = false, optional = true }
 smol = { version = "2", default-features = false, optional = true }
 tokio = { workspace = true, optional = true }
 
@@ -40,9 +40,9 @@ arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 async-compat = { version = "0.2", default-features = false }
-datafusion = { version = ">=52.1.0", default-features = false, features = ["parquet", "parquet_encryption"] }
+datafusion = { version = ">=52.1.0, <54", default-features = false, features = ["parquet", "parquet_encryption"] }
 futures = { workspace = true }
-object_store = { version = ">=0.12.5", default-features = false }
+object_store = { version = ">=0.12.5, <0.14", default-features = false }
 parquet = { workspace = true, features = ["arrow"] }
 paste = { version = "1.0" }
 tempfile = { workspace = true }

--- a/parquet-key-management/Cargo.toml
+++ b/parquet-key-management/Cargo.toml
@@ -23,15 +23,15 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 
 # optional
 async-std = { version = "1", optional = true }
-datafusion-execution = { version = "52.1.0", default-features = false, features = [
+datafusion-execution = { version = ">=52.1.0", default-features = false, features = [
   "parquet_encryption",
 ], optional = true }
-datafusion-common = { version = "52.1.0", default-features = false, features = [
+datafusion-common = { version = ">=52.1.0", default-features = false, features = [
   "parquet",
   "parquet_encryption",
 ], optional = true }
 futures = { workspace = true, optional = true }
-object_store = { version = "0.12.5", default-features = false, optional = true }
+object_store = { version = ">=0.12.5", default-features = false, optional = true }
 smol = { version = "2", default-features = false, optional = true }
 tokio = { workspace = true, optional = true }
 
@@ -40,16 +40,16 @@ arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 async-compat = { version = "0.2", default-features = false }
-datafusion = { version = "52.1.0", default-features = false, features = ["parquet", "parquet_encryption"] }
+datafusion = { version = ">=52.1.0", default-features = false, features = ["parquet", "parquet_encryption"] }
 futures = { workspace = true }
-object_store = { version = "0.12.5", default-features = false }
+object_store = { version = ">=0.12.5", default-features = false }
 parquet = { workspace = true, features = ["arrow"] }
 paste = { version = "1.0" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 url = { version = "2.5" }
 uuid = { version = "1.20", features = ["v4"] }
-deltalake-core = { git = "https://github.com/corwinjoy/delta-rs.git", branch = "file_format_options_squashed", features = [
+deltalake-core = { git = "https://github.com/G-Research-Forks/delta-rs", tag = "0.32.2-gr.1", features = [
   "datafusion",
 ] }
 

--- a/parquet-key-management/tests/delta_rs_kms.rs
+++ b/parquet-key-management/tests/delta_rs_kms.rs
@@ -505,7 +505,7 @@ async fn test_delete(file_format_options: FileFormatRef, decrypt_final_read: boo
 encryption_tests!(test_delete);
 
 async fn test_merge(file_format_options: FileFormatRef, decrypt_final_read: bool) {
-    let expected_str = vec![
+    let expected_str = [
         "+-----+--------+----------------------------+",
         "| int | string | timestamp                  |",
         "+-----+--------+----------------------------+",


### PR DESCRIPTION
* Loosens requirements for parquet, arrow, object_store and datafusion crates so consumers can use newer versions
* Updates the version of deltalake we test against, to use the new G-Research fork with encryption added
* Bumps patch version
* Workaround for an issue with taplo causing CI failures (we may want to later switch to tombi, taplo looks unmaintained)