### PR TITLE
security: pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: Lint Rust code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo
@@ -35,7 +35,7 @@ jobs:
     name: Lint TOML files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install taplo
         run: curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | sudo install -m 755 /dev/stdin /usr/local/bin/taplo
       - name: Format check
@@ -47,9 +47,9 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo
@@ -68,9 +68,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo
@@ -81,7 +81,7 @@ jobs:
       - name: Test
         run: cargo test --all-features --verbose
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -92,9 +92,9 @@ jobs:
     name: Verify minimum supported Rust version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo
@@ -145,7 +145,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Validate version
         run: |
           TAG_VERSION="${{ github.ref_name }}"
@@ -155,7 +155,7 @@ jobs:
             exit 1
           fi
       - name: Setup trusted publishing credentials
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec
         id: auth
       - name: Cargo publish
         run: cargo publish --verbose


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references in this repo to 40-character commit SHAs, replacing tag and branch references. This is a supply-chain hardening change with no expected functional impact — every SHA was resolved from its current tag/branch at audit time (2026-05-27).

## Why

Tag-pinned actions can be silently compromised if the upstream tag is rotated to a malicious commit. Branch-pinned actions (e.g. `@main`, `@release/v1`, `@stable`) are even riskier — anyone with push access upstream can change what runs in CI.

GitHub's own recommendation: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Notes

- Branch-pinned refs (`@main`, `@release/v1`, `@stable`) were resolved to the branch HEAD at audit time — re-verify before merge if the upstream branch has moved since.
- Part of an org-wide audit covering 26 G-Research repos. The full pinning plan and resolved SHAs are tracked in a local audit project.
- No functional change is expected; CI should pass identically.