### PR TITLE
Replace Taplo with Tombi for TOML checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Install taplo
-        run: curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | sudo install -m 755 /dev/stdin /usr/local/bin/taplo
+      - name: Install tombi
+        env:
+          TOMBI_SHA256: 6b01a72fbf67eb158a2efc72f7081756d87e2397054e0faf4de4b36478813342
+          TOMBI_VERSION: 1.1.1
+        run: |
+          temp_dir="$(mktemp -d)"
+          trap 'rm -rf "${temp_dir}"' EXIT
+          archive="${temp_dir}/tombi.tar.gz"
+          curl -fsSL -o "${archive}" "https://github.com/tombi-toml/tombi/releases/download/v${TOMBI_VERSION}/tombi-cli-${TOMBI_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${TOMBI_SHA256}  ${archive}" | sha256sum --check
+          tar -xzf "${archive}" -C "${temp_dir}"
+          sudo install -m 755 "${temp_dir}/tombi-cli-${TOMBI_VERSION}-x86_64-unknown-linux-musl/tombi" /usr/local/bin/tombi
       - name: Format check
-        run: taplo format --check
+        run: tombi format --check
       - name: Lint
-        run: taplo lint
+        run: tombi lint --error-on-warnings
 
   docs:
     name: Build docs

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,2 +1,0 @@
-[formatting]
-column_width = 120

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,9 @@
+[format.rules]
+line-width = 120
+
+[[schemas]]
+toml-version = "v1.0.0"
+path = "tombi://www.schemastore.org/cargo.json"
+include = ["Cargo.toml", "**/Cargo.toml"]
+format.rules.array-values-order.enabled = false
+format.rules.table-keys-order.enabled = false


### PR DESCRIPTION
## Summary

- replace the unmaintained Taplo TOML checks with Tombi
- migrate the existing 120-column formatter setting to `tombi.toml`
- pin Tombi `v1.1.1` and verify the published release SHA-256 before installation
- preserve strict lint behavior with `tombi lint --error-on-warnings`
- keep existing Cargo manifests stable by disabling Cargo schema sorting and selecting TOML `v1.0.0` for Cargo files

The Cargo schema setting is intentional: Tombi otherwise formats dependency inline tables using TOML 1.1 multiline syntax, while the repository's Cargo MSRV still expects TOML 1.0-compatible manifests.

Fixes #39.

## Validation

- `git diff --check origin/main...HEAD`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- parsed `tombi.toml` with Python `tomllib`
- syntax-checked the install block with `bash -n`
- downloaded Tombi `v1.1.1` and verified the pinned SHA-256
- `tombi format --check`
- `tombi lint --error-on-warnings`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path parquet-key-management/Cargo.toml`
- `cargo msrv verify --all-features --manifest-path parquet-key-management/Cargo.toml`
